### PR TITLE
合成ボタンをクリックしたら、音声が合成されるまで、再生ボタンを無効にする。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function App() {
 
   const onClickSynthesizeButton = async () => {
     const text = inputText;
+    setPlayButtonDisabled(true);
     SplishIpc.textToSynthesize(text).then((filename) => {
       setSFandPBD(filename);
     });


### PR DESCRIPTION
Fixes #16